### PR TITLE
Return the angular module so it can be consumed in applications

### DIFF
--- a/build/ngprogress.js
+++ b/build/ngprogress.js
@@ -231,5 +231,6 @@ angular.module('ngProgress.directive', [])
         return directiveObj;
     }]);
 
-angular.module('ngProgress', ['ngProgress.directive', 'ngProgress.provider']);
+    var ngProgress = angular.module('ngProgress', ['ngProgress.directive', 'ngProgress.provider']);
+    return ngProgress;
 }));


### PR DESCRIPTION
Was this working before?  

All I am doing here is returning the 'ngProgress' angular module and it becomes consumable in my typescript / angular 1.5 / webpack app using a commonjs require statement.
